### PR TITLE
fix: actually exclude pages that set ExcludeBoolFieldAlias

### DIFF
--- a/Blend.Sitemap/SitemapBuilder.cs
+++ b/Blend.Sitemap/SitemapBuilder.cs
@@ -107,7 +107,7 @@ namespace Blend.Sitemap
                 foreach (var alias in docType.Aliases)
                 {
                     var pages = root.DescendantsOrSelfOfType(alias, isoLanguageCode);
-                    if (!config.ExcludeBoolFieldAlias.HasValue())
+                    if (config.ExcludeBoolFieldAlias.HasValue())
                     {
                         pages = pages.Where(x =>
                             x.HasProperty(config.ExcludeBoolFieldAlias) &&


### PR DESCRIPTION
The current code excludes all pages that doesn't have the value for the `ExcludeBoolFieldAlias` field explicitly set to `false`. I think a safer handling is to include all pages except the ones that have the field set explicitly set to true. 

For instance if you add the sitemap package after one or more pages have been published with that field added to their model, or if the field would change the key, all pages will disappear from the sitemap except those that are published again.

I haven't tested the logic on a multilingual site, and I'm very welcome to input.