### PR TITLE
change changefreq and priority fallbacks

### DIFF
--- a/Blend.Sitemap/Assets/Views/Sitemap.cshtml
+++ b/Blend.Sitemap/Assets/Views/Sitemap.cshtml
@@ -29,8 +29,14 @@
             }
         }
         <lastmod>@item.UpdateDate</lastmod>
-        <changefreq>@item.ChangeFrequency</changefreq>
-        <priority>@item.Priority</priority>
+        @if (item.ChangeFrequency is not ChangeFrequency.omit)
+        {
+            <changefreq>@item.ChangeFrequency</changefreq>
+        }
+        @if (item.Priority is not null && item.Priority.Any())
+        {
+            <priority>@item.Priority</priority>
+        }
         @if (Model.IncludePageImages)
         {
             DisplayRelatedImages(item.ImageUrls);

--- a/Blend.Sitemap/SitemapBuilder.cs
+++ b/Blend.Sitemap/SitemapBuilder.cs
@@ -142,8 +142,8 @@ namespace Blend.Sitemap
 
         private SitemapPage GetPage(IPublishedContent content, SitemapDocumentTypeOptions type, string languageIsoCode)
         {
-            var priority = "1.0";
-            if (type.Priority < 10)
+            var priority = "";
+            if (type.Priority != 0 && type.Priority < 10)
                 priority = $"0.{type.Priority}";
 
             var page = new SitemapPage()

--- a/Blend.Sitemap/SitemapOptions.cs
+++ b/Blend.Sitemap/SitemapOptions.cs
@@ -61,14 +61,12 @@ namespace Blend.Sitemap
         /// <summary>
         /// How often the does the content in these document types change
         /// </summary>
-        [DefaultValue(ChangeFrequency.monthly)]
         [Description("How often the does the content in these document types change")]
         public ChangeFrequency ChangeFrequency { get; set; }
 
         /// <summary>
         /// What is the priority of these document types
         /// </summary>
-        [DefaultValue(5)]
         [Description("What is the priority of these document types")]
         public int Priority { get; set; }
     }
@@ -79,6 +77,7 @@ namespace Blend.Sitemap
     [Description("Options for Change Frequency")]
     public enum ChangeFrequency
     {
+        omit,
         always,
         hourly,
         daily,


### PR DESCRIPTION
This PR adds "omit" as the first constant in the ChangeFrequency enum, which is being used to show/hide the changefreq in the sitemap when a user does not specify the ChangeFrequency in appsettings.json (currently defaults to "always"). 

Added logic to hide the priority, if not set in appsettings.json (currently defaults to 0 when not set, and displays as 0.0)

